### PR TITLE
회원가입 제약조건 구현

### DIFF
--- a/board/src/main/java/hamkke/board/model/user/Alias.java
+++ b/board/src/main/java/hamkke/board/model/user/Alias.java
@@ -1,0 +1,39 @@
+package hamkke.board.model.user;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public class Alias {
+
+    private static final String ALIAS_PATTERN = "^[a-z0-9가-힣]{1,8}$";
+
+    private final String value;
+
+    public Alias(final String inputAlias) {
+        validateByAliasPattern(inputAlias);
+        value = inputAlias;
+    }
+
+    private void validateByAliasPattern(final String inputAlias) {
+        if (!Pattern.matches(ALIAS_PATTERN, inputAlias)) {
+            throw new IllegalArgumentException("별칭은 특수문자와 영어(대문자)를 제외하여 8자 이하여야 합니다.");
+        }
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Alias alias = (Alias) o;
+        return Objects.equals(value, alias.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/board/src/main/java/hamkke/board/model/user/Password.java
+++ b/board/src/main/java/hamkke/board/model/user/Password.java
@@ -1,0 +1,25 @@
+package hamkke.board.model.user;
+
+import java.util.regex.Pattern;
+
+public class Password {
+
+    public static final String PASSWORD_PATTERN = "^([a-z0-9!@#$%^&*_-]){8,18}$";
+
+    private final String value;
+
+    public Password(final String inputPassword) {
+        validateByPasswordPattern(inputPassword);
+        value = inputPassword;
+    }
+
+    private void validateByPasswordPattern(final String inputPassword) {
+        if (!Pattern.matches(PASSWORD_PATTERN, inputPassword)) {
+            throw new IllegalArgumentException("비밀번호는 영문(대문자,소문자), 특수문자(!,@,#,$,%,^,&,*,_,-), 숫자를 최소 1개 이상 조합한 8자 이상 18자 이하여야합니다.");
+        }
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/board/src/main/java/hamkke/board/model/user/UserId.java
+++ b/board/src/main/java/hamkke/board/model/user/UserId.java
@@ -7,8 +7,6 @@ public class UserId {
 
     public static final String USER_ID_PATTERN = "^[a-z][a-z0-9]{5,19}$";
 
-    public static final String BLANK = " ";
-
     private final String value;
 
     public UserId(final String inputUserId) {

--- a/board/src/main/java/hamkke/board/model/user/UserId.java
+++ b/board/src/main/java/hamkke/board/model/user/UserId.java
@@ -1,0 +1,41 @@
+package hamkke.board.model.user;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+public class UserId {
+
+    public static final String USER_ID_PATTERN = "^[a-z][a-z0-9]{5,19}$";
+
+    public static final String BLANK = " ";
+
+    private final String value;
+
+    public UserId(final String inputUserId) {
+        validate(inputUserId);
+        value = inputUserId;
+    }
+
+    private void validate(String inputUserId) {
+        if (!Pattern.matches(USER_ID_PATTERN, inputUserId)) {
+            throw new IllegalArgumentException("유저의 아이디는 영문자(소문자)와 숫자의 조합으로 6자 이상 20자 이하여야합니다.");
+        }
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserId userId = (UserId) o;
+        return Objects.equals(value, userId.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/board/src/main/java/hamkke/board/model/user/UserId.java
+++ b/board/src/main/java/hamkke/board/model/user/UserId.java
@@ -5,7 +5,7 @@ import java.util.regex.Pattern;
 
 public class UserId {
 
-    public static final String USER_ID_PATTERN = "^[a-z][a-z0-9]{5,19}$";
+    public static final String USER_ID_PATTERN = "^([a-z][a-z0-9]){5,20}$";
 
     private final String value;
 

--- a/board/src/main/java/hamkke/board/model/user/UserId.java
+++ b/board/src/main/java/hamkke/board/model/user/UserId.java
@@ -18,7 +18,7 @@ public class UserId {
 
     private void validate(String inputUserId) {
         if (!Pattern.matches(USER_ID_PATTERN, inputUserId)) {
-            throw new IllegalArgumentException("유저의 아이디는 영문자(소문자)와 숫자의 조합으로 6자 이상 20자 이하여야합니다.");
+            throw new IllegalArgumentException("유저의 아이디는 공백을 제외하고, 영문자(소문자)로 시작한 영문자(소문자)와 숫자의 조합으로 6자 이상 20자 이하여야합니다.");
         }
     }
 

--- a/board/src/main/java/hamkke/board/model/user/UserId.java
+++ b/board/src/main/java/hamkke/board/model/user/UserId.java
@@ -10,11 +10,11 @@ public class UserId {
     private final String value;
 
     public UserId(final String inputUserId) {
-        validate(inputUserId);
+        validateByUserIdPattern(inputUserId);
         value = inputUserId;
     }
 
-    private void validate(String inputUserId) {
+    private void validateByUserIdPattern(final String inputUserId) {
         if (!Pattern.matches(USER_ID_PATTERN, inputUserId)) {
             throw new IllegalArgumentException("유저의 아이디는 공백을 제외하고, 영문자(소문자)로 시작한 영문자(소문자)와 숫자의 조합으로 6자 이상 20자 이하여야합니다.");
         }

--- a/board/src/test/java/hamkke/board/model/user/AliasTest.java
+++ b/board/src/test/java/hamkke/board/model/user/AliasTest.java
@@ -15,8 +15,7 @@ class AliasTest {
     @ValueSource(strings = {"!apple", "APPLE", "가나다라마바사아자", " ", ""})
     void validateAlias(final String inputAlias) {
         //when, then
-        assertThatThrownBy(() -> new Alias(inputAlias))
-                .isInstanceOf(IllegalArgumentException.class)
+        assertThatThrownBy(() -> new Alias(inputAlias)).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("별칭은 특수문자와 영어(대문자)를 제외하여 8자 이하여야 합니다.");
     }
 

--- a/board/src/test/java/hamkke/board/model/user/AliasTest.java
+++ b/board/src/test/java/hamkke/board/model/user/AliasTest.java
@@ -1,0 +1,36 @@
+package hamkke.board.model.user;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AliasTest {
+
+    @ParameterizedTest
+    @DisplayName("별칭은 특수문자와 영어(대문자)를 제외하여 8자 이하여야 합니다.")
+    @ValueSource(strings = {"!apple", "APPLE", "가나다라마바사아자", " ", ""})
+    void validateAlias(final String inputAlias) {
+        //when, then
+        assertThatThrownBy(() -> new Alias(inputAlias))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("별칭은 특수문자와 영어(대문자)를 제외하여 8자 이하여야 합니다.");
+    }
+
+    @Test
+    @DisplayName("별칭을 반환한다.")
+    void getValue() {
+        //given
+        String inputAlias = "사과왕77";
+        Alias alias = new Alias(inputAlias);
+
+        //when
+        String actual = alias.getValue();
+
+        //then
+        assertThat(actual).isEqualTo("사과왕77");
+    }
+}

--- a/board/src/test/java/hamkke/board/model/user/PasswordTest.java
+++ b/board/src/test/java/hamkke/board/model/user/PasswordTest.java
@@ -1,0 +1,35 @@
+package hamkke.board.model.user;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PasswordTest {
+
+    @ParameterizedTest
+    @DisplayName("비밀번호는 영문(대문자,소문자), 특수문자(!,@,#,$,%,^,&,*,_,-), 숫자를 최소 1개 이상 조합한 8자 이상 18자 이하여야합니다.")
+    @ValueSource(strings = {"apple1!", "0123456789012345a1!", "appleBanana1", "appleBanana!", "apple012345?", "     apple", ""})
+    void validate(final String inputPassword) {
+
+        //when, then
+        assertThatThrownBy(() -> new Password(inputPassword)).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("비밀번호는 영문(대문자,소문자), 특수문자(!,@,#,$,%,^,&,*,_,-), 숫자를 최소 1개 이상 조합한 8자 이상 18자 이하여야합니다.");
+    }
+
+    @Test
+    @DisplayName("비밀번호를 반환한다.")
+    void getValue() {
+        //given
+        Password password = new Password("apple12345!@");
+
+        //when
+        String actual = password.getValue();
+
+        //then
+        assertThat(actual).isEqualTo("apple12345!@");
+    }
+}

--- a/board/src/test/java/hamkke/board/model/user/UserIdTest.java
+++ b/board/src/test/java/hamkke/board/model/user/UserIdTest.java
@@ -1,0 +1,36 @@
+package hamkke.board.model.user;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+
+class UserIdTest {
+
+    @ParameterizedTest
+    @DisplayName("유저의 아이디는 영문자(소문자)와 숫자의 조합으로 6자 이상 20자 이하여야합니다.")
+    @ValueSource(strings = {"1apple", "_apple", " apple", "apple", "a12345678901234567890", "apple!", "@apple", "apple_hi", "", " "})
+    void validateUserId(final String inputUserId) {
+        //when, then
+        assertThatThrownBy(() -> new UserId(inputUserId))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("유저의 아이디는 영문자(소문자)와 숫자의 조합으로 6자 이상 20자 이하여야합니다.");
+    }
+
+    @Test
+    @DisplayName("유저 아이디를 반환하다.")
+    void getValue() {
+        //given
+        UserId apple = new UserId("banana12");
+
+        //when
+        String actual = apple.getValue();
+
+        //then
+        assertThat(actual).isEqualTo("banana12");
+    }
+}

--- a/board/src/test/java/hamkke/board/model/user/UserIdTest.java
+++ b/board/src/test/java/hamkke/board/model/user/UserIdTest.java
@@ -16,8 +16,7 @@ class UserIdTest {
     @ValueSource(strings = {"1apple", "_apple", " apple", "apple", "a12345678901234567890", "apple!", "@apple", "apple_hi", "", " "})
     void validateUserId(final String inputUserId) {
         //when, then
-        assertThatThrownBy(() -> new UserId(inputUserId))
-                .isInstanceOf(IllegalArgumentException.class)
+        assertThatThrownBy(() -> new UserId(inputUserId)).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("유저의 아이디는 공백을 제외하고, 영문자(소문자)로 시작한 영문자(소문자)와 숫자의 조합으로 6자 이상 20자 이하여야합니다.");
     }
 

--- a/board/src/test/java/hamkke/board/model/user/UserIdTest.java
+++ b/board/src/test/java/hamkke/board/model/user/UserIdTest.java
@@ -12,13 +12,13 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 class UserIdTest {
 
     @ParameterizedTest
-    @DisplayName("유저의 아이디는 영문자(소문자)와 숫자의 조합으로 6자 이상 20자 이하여야합니다.")
+    @DisplayName("유저의 아이디는 공백 제외 영문자(소문자)와 숫자의 조합으로 6자 이상 20자 이하여야합니다.")
     @ValueSource(strings = {"1apple", "_apple", " apple", "apple", "a12345678901234567890", "apple!", "@apple", "apple_hi", "", " "})
     void validateUserId(final String inputUserId) {
         //when, then
         assertThatThrownBy(() -> new UserId(inputUserId))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("유저의 아이디는 영문자(소문자)와 숫자의 조합으로 6자 이상 20자 이하여야합니다.");
+                .hasMessage("유저의 아이디는 공백을 제외하고, 영문자(소문자)로 시작한 영문자(소문자)와 숫자의 조합으로 6자 이상 20자 이하여야합니다.");
     }
 
     @Test


### PR DESCRIPTION
회원가입 관련 제약조건 
- 아이디 
   공백제외
   영문자(소문자) 와 숫자의 조합
   아이디의 길이는 6자 이상 20자 이하

- 비밀번호
   공백제외
   비밀번호는 영문(대문자,소문자), 특수문자(!,@,#,$,%,^,&,*,_,-), 숫자를 최소 1개 이상 조합
   길이는 8자 이상 18자 이하

- 별칭
   공백제외
   특수문자 영어(대문자)를 제외한 문자열
   길이는 8자 이하


다음의 요구사항에 해당하는 클래스를 구현 하였습니다.