### PR TITLE
Feature/#42/소나큐브_이전

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.7.4'
 	id 'io.spring.dependency-management' version '1.0.14.RELEASE'
 	id 'java'
-	id "org.sonarqube" version "3.4.0.2513"
+	id "org.sonarqube" version "3.5.0.2730"
 }
 
 group = 'hamkke'


### PR DESCRIPTION
# 소나 큐브 이전
### 이슈 번호 : #42 
## 변경 사항 
- 소나큐브를 젠킨스 용 ec2로 이전에 따른 플러그인 변경
   
## 그 외
- 없음

## 질문 사항
- 없음