### PR TITLE
Feature/#52/회원 별명 변경 기능 컨트롤러

### DIFF
--- a/src/main/java/hamkke/board/controller/UserController.java
+++ b/src/main/java/hamkke/board/controller/UserController.java
@@ -2,16 +2,15 @@ package hamkke.board.controller;
 
 import hamkke.board.service.UserService;
 import hamkke.board.service.dto.CreateUserRequest;
+import hamkke.board.service.dto.UserChangeAliasRequest;
 import hamkke.board.service.dto.UserResponse;
+import hamkke.board.web.argumentresolver.Login;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequestMapping("/api/user")
@@ -27,5 +26,12 @@ public class UserController {
         String joinedUserLoginId = userService.join(createUserRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new UserResponse(joinedUserLoginId));
+    }
+
+    @PutMapping("/change-alias")
+    public ResponseEntity<Void> changeAlias(@Login final String loginId, @Validated @RequestBody final UserChangeAliasRequest userChangeAliasRequest) {
+        log.info("alias 변경 요청 newAlias = {}", userChangeAliasRequest.getNewAlias());
+        userService.changeAlias(loginId, userChangeAliasRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/hamkke/board/domain/user/User.java
+++ b/src/main/java/hamkke/board/domain/user/User.java
@@ -63,6 +63,10 @@ public class User extends BaseEntity {
         password.checkPassword(otherPassword);
     }
 
+    public void changeAlias(final String newAlias) {
+        alias.changeValue(newAlias);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/src/main/java/hamkke/board/domain/user/vo/Alias.java
+++ b/src/main/java/hamkke/board/domain/user/vo/Alias.java
@@ -33,4 +33,9 @@ public class Alias {
     public String getValue() {
         return value;
     }
+
+    public void changeValue(final String newAlias) {
+        validateByAliasPattern(newAlias);
+        this.value = newAlias;
+    }
 }

--- a/src/main/java/hamkke/board/service/UserService.java
+++ b/src/main/java/hamkke/board/service/UserService.java
@@ -3,6 +3,7 @@ package hamkke.board.service;
 import hamkke.board.domain.user.User;
 import hamkke.board.repository.UserRepository;
 import hamkke.board.service.dto.CreateUserRequest;
+import hamkke.board.service.dto.UserChangeAliasRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -36,5 +37,15 @@ public class UserService {
     public User findByLoginId(final String loginId) {
         return userRepository.findByLoginIdValue(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 ID 입니다."));
+    }
+
+    @Transactional
+    public void changeAlias(final String loginId, final UserChangeAliasRequest userChangeAliasRequest) {
+        User user = userRepository.findByLoginIdValue(loginId)
+                .orElseThrow(() -> {
+                    log.info("존재하지 않는 loginId의 접근 : {}", loginId);
+                    throw new IllegalArgumentException("존재하지 않는 유저입니다.");
+                });
+        user.changeAlias(userChangeAliasRequest.getNewAlias());
     }
 }

--- a/src/main/java/hamkke/board/service/dto/UserChangeAliasRequest.java
+++ b/src/main/java/hamkke/board/service/dto/UserChangeAliasRequest.java
@@ -1,0 +1,21 @@
+package hamkke.board.service.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserChangeAliasRequest {
+
+    @NotNull
+    @Pattern(regexp = "^[a-z0-9가-힣]{2,8}$", message = "별칭은 특수문자와 영어(대문자)를 제외하여 1자 이상, 8자 이하여야 합니다.")
+    private String newAlias;
+
+    public UserChangeAliasRequest(final String newAlias) {
+        this.newAlias = newAlias;
+    }
+}

--- a/src/test/java/hamkke/board/controller/UserControllerTest.java
+++ b/src/test/java/hamkke/board/controller/UserControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -94,7 +95,7 @@ class UserControllerTest {
         UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("새로운별명");
 
         //when
-        ResultActions actual = mockMvc.perform(post("/api/user/change-alias").contentType(MediaType.APPLICATION_JSON)
+        ResultActions actual = mockMvc.perform(put("/api/user/change-alias").contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
 
         //then

--- a/src/test/java/hamkke/board/controller/UserControllerTest.java
+++ b/src/test/java/hamkke/board/controller/UserControllerTest.java
@@ -3,6 +3,7 @@ package hamkke.board.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hamkke.board.service.UserService;
 import hamkke.board.service.dto.CreateUserRequest;
+import hamkke.board.service.dto.UserChangeAliasRequest;
 import hamkke.board.web.jwt.TokenResolver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -84,5 +85,35 @@ class UserControllerTest {
         //then
         actual.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("이미 존재하는 별명 입니다."));
+    }
+
+    @Test
+    @DisplayName("별명 변경 시, 새로운 별명을 입력받으면 HTTP 200 상태코드를 반환한다.")
+    void changeAlias() throws Exception {
+        //given
+        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("새로운별명");
+
+        //when
+        ResultActions actual = mockMvc.perform(post("/api/user/change-alias").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
+
+        //then
+        actual.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("별명 변경 시, 이미 사용중인 별명이라면 HTTP 400 상태코드를 반환한다.")
+    void changeAliasFailedByDuplication() throws Exception {
+        //given
+        when(userService.changeAlias(any(UserChangeAliasRequest.class))).thenThrow(new IllegalArgumentException("이미 사용중인 별명입니다."));
+
+        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("존재하는별명");
+
+        //when
+        ResultActions actual = mockMvc.perform(post("/api/user/change-alias").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
+
+        //then
+        actual.andExpect(status().isOk());
     }
 }

--- a/src/test/java/hamkke/board/controller/UserControllerTest.java
+++ b/src/test/java/hamkke/board/controller/UserControllerTest.java
@@ -105,7 +105,7 @@ class UserControllerTest {
     @DisplayName("별명 변경 시, 이미 사용중인 별명이라면 HTTP 400 상태코드를 반환한다.")
     void changeAliasFailedByDuplication() throws Exception {
         //given
-        when(userService.changeAlias(any(UserChangeAliasRequest.class))).thenThrow(new IllegalArgumentException("이미 사용중인 별명입니다."));
+        when(userService.changeAlias(any(UserChangeAliasRequest.class))).thenThrow(new IllegalArgumentException("이미 존재하는 별명입니다."));
 
         UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("존재하는별명");
 

--- a/src/test/java/hamkke/board/domain/user/UserTest.java
+++ b/src/test/java/hamkke/board/domain/user/UserTest.java
@@ -1,0 +1,70 @@
+package hamkke.board.domain.user;
+
+import hamkke.board.domain.bulletin.Bulletin;
+import hamkke.board.domain.user.vo.Alias;
+import hamkke.board.domain.user.vo.LoginId;
+import hamkke.board.domain.user.vo.Password;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    private User createUser() {
+        final String loginId = "apple123";
+        final String password = "apple123!!";
+        final String alias = "삼다수";
+        return new User(loginId, password, alias);
+    }
+
+    private Bulletin createBulletin(final User author) {
+        final String title = "sample title";
+        final String content = "sample content";
+        return new Bulletin(title, content, author);
+    }
+
+    @Test
+    @DisplayName("유저 아이디, 비밀번호, 별칭, 생성 일자를 반환한다.")
+    void getValues() {
+        //given
+        SoftAssertions softly = new SoftAssertions();
+        User user = createUser();
+
+        //when, then
+        softly.assertThat(user.getLoginId()).isEqualTo(new LoginId("apple123"));
+        softly.assertThat(user.getPassword()).isEqualTo(new Password("apple123!!"));
+        softly.assertThat(user.getAlias()).isEqualTo(new Alias("삼다수"));
+        softly.assertAll();
+    }
+
+    @Test
+    @DisplayName("연관 관계 편의 메서드")
+    void addBulletin() {
+        //given
+        User user = createUser();
+        Bulletin bulletin = createBulletin(user);
+
+        //when
+        user.addBulletin(bulletin);
+
+        //then
+        assertThat(user.getBulletins()).contains(bulletin);
+    }
+
+
+    @Test
+    @DisplayName("Alias 를 변경한다.")
+    void changeAlias() {
+        //given
+        User user = createUser();
+        String newAlias = "백산수";
+
+        //when
+        user.changeAlias(newAlias);
+
+        //then
+        assertThat(user.getAlias().getValue()).isEqualTo("백산수");
+    }
+}

--- a/src/test/java/hamkke/board/domain/user/UserTest.java
+++ b/src/test/java/hamkke/board/domain/user/UserTest.java
@@ -53,7 +53,6 @@ class UserTest {
         assertThat(user.getBulletins()).contains(bulletin);
     }
 
-
     @Test
     @DisplayName("Alias 를 변경한다.")
     void changeAlias() {

--- a/src/test/java/hamkke/board/domain/user/vo/AliasTest.java
+++ b/src/test/java/hamkke/board/domain/user/vo/AliasTest.java
@@ -39,4 +39,18 @@ class AliasTest {
         //then
         assertThat(actual).isEqualTo("사과왕77");
     }
+
+    @Test
+    @DisplayName("별칭을 변경한다.")
+    void changeValue() {
+        //given
+        Alias alias = new Alias("삼다수");
+        String input = "백산수";
+
+        //when
+        alias.changeValue(input);
+
+        //then
+        assertThat(alias.getValue()).isEqualTo("백산수");
+    }
 }

--- a/src/test/java/hamkke/board/domain/user/vo/AliasTest.java
+++ b/src/test/java/hamkke/board/domain/user/vo/AliasTest.java
@@ -19,7 +19,7 @@ class AliasTest {
 
     @ParameterizedTest
     @DisplayName("별칭은 특수문자와 영어(대문자)를 제외하여 8자 이하여야 합니다. 그렇지 않은 경우 예외를 발생한다.")
-    @ValueSource(strings = {"!apple", "APPLE", "가나다라마바사아자","a", " ", ""})
+    @ValueSource(strings = {"!apple", "APPLE", "가나다라마바사아자", "a", " ", ""})
     void validateAlias(final String inputAlias) {
         //when, then
         assertThatThrownBy(() -> new Alias(inputAlias)).isInstanceOf(IllegalArgumentException.class)
@@ -52,5 +52,17 @@ class AliasTest {
 
         //then
         assertThat(alias.getValue()).isEqualTo("백산수");
+    }
+
+    @ParameterizedTest
+    @DisplayName("별칭 변경 시, 지정된 제약조건(별칭은 특수문자와 영어(대문자)를 제외하여 8자 이하여야 한다.)에 위배되면 예외를 발생한다.")
+    @ValueSource(strings = {"!apple", "APPLE", "가나다라마바사아자", "a", " ", ""})
+    void validateWhenChangeAlias(final String newAlias) {
+        //given
+        Alias alias = new Alias("삼다수");
+
+        //when, then
+        assertThatThrownBy(() -> alias.changeValue(newAlias))
+                .hasMessage("별칭은 특수문자와 영어(대문자)를 제외하여 1자 이상, 8자 이하여야 합니다.");
     }
 }

--- a/src/test/java/hamkke/board/service/UserServiceTest.java
+++ b/src/test/java/hamkke/board/service/UserServiceTest.java
@@ -4,12 +4,15 @@ import hamkke.board.domain.user.User;
 import hamkke.board.domain.user.vo.LoginId;
 import hamkke.board.repository.UserRepository;
 import hamkke.board.service.dto.CreateUserRequest;
+import hamkke.board.service.dto.UserChangeAliasRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -79,5 +82,21 @@ class UserServiceTest {
         //when, then
         assertThatThrownBy(() -> userService.join(duplicated)).isInstanceOf(IllegalStateException.class)
                 .hasMessage("이미 존재하는 별명 입니다.");
+    }
+
+    @Test
+    @DisplayName("User 의 Alias 를 변경한다.")
+    void changeAlias() {
+        //given
+        when(userRepository.findByLoginIdValue(anyString())).thenReturn(Optional.of(user));
+        String loginId = "apple123";
+        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("백산수");
+
+        //when
+        userService.changeAlias(loginId, userChangeAliasRequest);
+
+        //then
+        verify(userRepository, times(1)).findByLoginIdValue(anyString());
+        verify(user,times(1)).changeAlias(anyString());
     }
 }


### PR DESCRIPTION
# 회원 별명 변경 기능 컨트롤러
### 이슈 번호 : #52 
## 변경 사항 
- 컨트롤러 단 변경을 먼저 해보았습니다.
   
## 그 외
- 없음

## 질문 사항
- 이전에 @seonghun127 형님께서 컨트롤러 -> 엔티티 -> 서비스 순으로 이슈를 쪼개보라고 하셔서 한번 해보았습니다.
이렇게 하면 될까요??
변경 로직의 전체적인 흐름이 보이지가 않아서 일단 보이는 것들 우선으로 코드 작성해보았습니다.

아직 service 레벨의 메서드는 만들어지지 않아서, 컨트롤러의 구현 코드와 테스트 코드가 컴파일 에러가 난 상태로 커밋을 해두었습니다.
  -> `userService.changeAlias` 메서드를 구현하지 않고 명시만 해두었습니다.