### PR TITLE
Feature/#54/회원 별명 변경 기능 엔티티

### DIFF
--- a/src/main/java/hamkke/board/domain/user/User.java
+++ b/src/main/java/hamkke/board/domain/user/User.java
@@ -63,6 +63,10 @@ public class User extends BaseEntity {
         password.checkPassword(otherPassword);
     }
 
+    public void changeAlias(final String newAlias) {
+        alias.changeValue(newAlias);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/src/main/java/hamkke/board/domain/user/vo/Alias.java
+++ b/src/main/java/hamkke/board/domain/user/vo/Alias.java
@@ -33,4 +33,9 @@ public class Alias {
     public String getValue() {
         return value;
     }
+
+    public void changeValue(final String newAlias) {
+        validateByAliasPattern(newAlias);
+        this.value = newAlias;
+    }
 }

--- a/src/test/java/hamkke/board/domain/user/UserTest.java
+++ b/src/test/java/hamkke/board/domain/user/UserTest.java
@@ -1,0 +1,70 @@
+package hamkke.board.domain.user;
+
+import hamkke.board.domain.bulletin.Bulletin;
+import hamkke.board.domain.user.vo.Alias;
+import hamkke.board.domain.user.vo.LoginId;
+import hamkke.board.domain.user.vo.Password;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    private User createUser() {
+        final String loginId = "apple123";
+        final String password = "apple123!!";
+        final String alias = "삼다수";
+        return new User(loginId, password, alias);
+    }
+
+    private Bulletin createBulletin(final User author) {
+        final String title = "sample title";
+        final String content = "sample content";
+        return new Bulletin(title, content, author);
+    }
+
+    @Test
+    @DisplayName("유저 아이디, 비밀번호, 별칭, 생성 일자를 반환한다.")
+    void getValues() {
+        //given
+        SoftAssertions softly = new SoftAssertions();
+        User user = createUser();
+
+        //when, then
+        softly.assertThat(user.getLoginId()).isEqualTo(new LoginId("apple123"));
+        softly.assertThat(user.getPassword()).isEqualTo(new Password("apple123!!"));
+        softly.assertThat(user.getAlias()).isEqualTo(new Alias("삼다수"));
+        softly.assertAll();
+    }
+
+    @Test
+    @DisplayName("연관 관계 편의 메서드")
+    void addBulletin() {
+        //given
+        User user = createUser();
+        Bulletin bulletin = createBulletin(user);
+
+        //when
+        user.addBulletin(bulletin);
+
+        //then
+        assertThat(user.getBulletins()).contains(bulletin);
+    }
+
+
+    @Test
+    @DisplayName("Alias 를 변경한다.")
+    void changeAlias() {
+        //given
+        User user = createUser();
+        String newAlias = "백산수";
+
+        //when
+        user.changeAlias(newAlias);
+
+        //then
+        assertThat(user.getAlias().getValue()).isEqualTo("백산수");
+    }
+}

--- a/src/test/java/hamkke/board/domain/user/vo/AliasTest.java
+++ b/src/test/java/hamkke/board/domain/user/vo/AliasTest.java
@@ -39,4 +39,18 @@ class AliasTest {
         //then
         assertThat(actual).isEqualTo("사과왕77");
     }
+
+    @Test
+    @DisplayName("별칭을 변경한다.")
+    void changeValue() {
+        //given
+        Alias alias = new Alias("삼다수");
+        String input = "백산수";
+
+        //when
+        alias.changeValue(input);
+
+        //then
+        assertThat(alias.getValue()).isEqualTo("백산수");
+    }
 }


### PR DESCRIPTION
# 회원 별명 변경 기능 컨트롤러
### 이슈 번호 : #54 
## 변경 사항 
- User 의 Alias 를 변경하기 위한 로직추가 
- 누락되었던 User 테스트 코드 작성
   
## 그 외
- 없음

## 질문 사항
- 없음