### PR TITLE
Feature/#59/회원 별명 변경 기능 서비스

### DIFF
--- a/src/main/java/hamkke/board/service/UserService.java
+++ b/src/main/java/hamkke/board/service/UserService.java
@@ -3,6 +3,7 @@ package hamkke.board.service;
 import hamkke.board.domain.user.User;
 import hamkke.board.repository.UserRepository;
 import hamkke.board.service.dto.CreateUserRequest;
+import hamkke.board.service.dto.UserChangeAliasRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -36,5 +37,15 @@ public class UserService {
     public User findByLoginId(final String loginId) {
         return userRepository.findByLoginIdValue(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 ID 입니다."));
+    }
+
+    @Transactional
+    public void changeAlias(final String loginId, final UserChangeAliasRequest userChangeAliasRequest) {
+        User user = userRepository.findByLoginIdValue(loginId)
+                .orElseThrow(() -> {
+                    log.info("존재하지 않는 loginId의 접근 : {}", loginId);
+                    throw new IllegalArgumentException("존재하지 않는 유저입니다.");
+                });
+        user.changeAlias(userChangeAliasRequest.getNewAlias());
     }
 }

--- a/src/test/java/hamkke/board/service/UserServiceTest.java
+++ b/src/test/java/hamkke/board/service/UserServiceTest.java
@@ -4,12 +4,15 @@ import hamkke.board.domain.user.User;
 import hamkke.board.domain.user.vo.LoginId;
 import hamkke.board.repository.UserRepository;
 import hamkke.board.service.dto.CreateUserRequest;
+import hamkke.board.service.dto.UserChangeAliasRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -79,5 +82,21 @@ class UserServiceTest {
         //when, then
         assertThatThrownBy(() -> userService.join(duplicated)).isInstanceOf(IllegalStateException.class)
                 .hasMessage("이미 존재하는 별명 입니다.");
+    }
+
+    @Test
+    @DisplayName("User 의 Alias 를 변경한다.")
+    void changeAlias() {
+        //given
+        when(userRepository.findByLoginIdValue(anyString())).thenReturn(Optional.of(user));
+        String loginId = "apple123";
+        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("백산수");
+
+        //when
+        userService.changeAlias(loginId, userChangeAliasRequest);
+
+        //then
+        verify(userRepository, times(1)).findByLoginIdValue(anyString());
+        verify(user,times(1)).changeAlias(anyString());
     }
 }


### PR DESCRIPTION
# 회원 별명 변경 기능 서비스
### 이슈 번호 : #59 
## 변경 사항 
- 서비스 단의 Alias 변경 로직 추가
   
## 그 외
- 컨트롤러, 엔티티, 서비스 간에 브랜치를 나누어서 각각 작업 해보았는데,,, 각 브랜치간 맥락이 한눈에 보이지가 않아서 어려웠습니다.. 
 특히 테스트 코드 작성 시, 존재하지 않는 코드에 대한 테스트를 작성해야하기 때문에 어떻게 mocking을 해야할지 어려웠습니다.

- 서비스 수정중에 컨트롤러에 대한 잘못된 코드가 있어서 컨트롤러 수정을 하면
 컨트롤러 -> 엔티티 -> 서비스 브랜치 순서로 각각 pull 과 push 를 하다보니 브랜치 관리가 상당히 복잡해졌습니다..

- 테스트 코드를 작성해야한다고 생각하는데, 일단 현재 까지의 변경을 통합하여 새로운 브랜치에서 하는게 좋다고 생각해서 현재까지 작업내역만 pr 올립니다.

## 질문 사항
- 없음