### PR TITLE
Feature/#52/회원 별명 변경 기능 구현

### DIFF
--- a/src/main/java/hamkke/board/controller/UserController.java
+++ b/src/main/java/hamkke/board/controller/UserController.java
@@ -28,10 +28,11 @@ public class UserController {
                 .body(new UserResponse(joinedUserLoginId));
     }
 
-    @PutMapping("/change-alias")
+    @PutMapping("/alias")
     public ResponseEntity<Void> changeAlias(@Login final String loginId, @Validated @RequestBody final UserChangeAliasRequest userChangeAliasRequest) {
         log.info("alias 변경 요청 newAlias = {}", userChangeAliasRequest.getNewAlias());
         userService.changeAlias(loginId, userChangeAliasRequest);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok()
+                .build();
     }
 }

--- a/src/main/java/hamkke/board/controller/UserController.java
+++ b/src/main/java/hamkke/board/controller/UserController.java
@@ -2,16 +2,15 @@ package hamkke.board.controller;
 
 import hamkke.board.service.UserService;
 import hamkke.board.service.dto.CreateUserRequest;
+import hamkke.board.service.dto.UserChangeAliasRequest;
 import hamkke.board.service.dto.UserResponse;
+import hamkke.board.web.argumentresolver.Login;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequestMapping("/api/user")
@@ -27,5 +26,12 @@ public class UserController {
         String joinedUserLoginId = userService.join(createUserRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(new UserResponse(joinedUserLoginId));
+    }
+
+    @PutMapping("/change-alias")
+    public ResponseEntity<Void> changeAlias(@Login final String loginId, @Validated @RequestBody final UserChangeAliasRequest userChangeAliasRequest) {
+        log.info("alias 변경 요청 newAlias = {}", userChangeAliasRequest.getNewAlias());
+        userService.changeAlias(loginId, userChangeAliasRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/hamkke/board/controller/UserController.java
+++ b/src/main/java/hamkke/board/controller/UserController.java
@@ -2,7 +2,7 @@ package hamkke.board.controller;
 
 import hamkke.board.service.UserService;
 import hamkke.board.service.dto.CreateUserRequest;
-import hamkke.board.service.dto.UserChangeAliasRequest;
+import hamkke.board.service.dto.UserAliasChangeRequest;
 import hamkke.board.service.dto.UserResponse;
 import hamkke.board.web.argumentresolver.Login;
 import lombok.RequiredArgsConstructor;
@@ -29,9 +29,9 @@ public class UserController {
     }
 
     @PutMapping("/alias")
-    public ResponseEntity<Void> changeAlias(@Login final String loginId, @Validated @RequestBody final UserChangeAliasRequest userChangeAliasRequest) {
-        log.info("loginId = {} 의 alias 변경 요청 newAlias = {}", loginId, userChangeAliasRequest.getNewAlias());
-        userService.changeAlias(loginId, userChangeAliasRequest);
+    public ResponseEntity<Void> changeAlias(@Login final String loginId, @Validated @RequestBody final UserAliasChangeRequest userAliasChangeRequest) {
+        log.info("loginId = {} 의 alias 변경 요청 newAlias = {}", loginId, userAliasChangeRequest.getNewAlias());
+        userService.changeAlias(loginId, userAliasChangeRequest);
         return ResponseEntity.ok()
                 .build();
     }

--- a/src/main/java/hamkke/board/controller/UserController.java
+++ b/src/main/java/hamkke/board/controller/UserController.java
@@ -30,7 +30,7 @@ public class UserController {
 
     @PutMapping("/alias")
     public ResponseEntity<Void> changeAlias(@Login final String loginId, @Validated @RequestBody final UserChangeAliasRequest userChangeAliasRequest) {
-        log.info("alias 변경 요청 newAlias = {}", userChangeAliasRequest.getNewAlias());
+        log.info("loginId = {} 의 alias 변경 요청 newAlias = {}", loginId, userChangeAliasRequest.getNewAlias());
         userService.changeAlias(loginId, userChangeAliasRequest);
         return ResponseEntity.ok()
                 .build();

--- a/src/main/java/hamkke/board/domain/user/User.java
+++ b/src/main/java/hamkke/board/domain/user/User.java
@@ -63,6 +63,10 @@ public class User extends BaseEntity {
         password.checkPassword(otherPassword);
     }
 
+    public void changeAlias(final String newAlias) {
+        alias.changeValue(newAlias);
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;

--- a/src/main/java/hamkke/board/domain/user/vo/Alias.java
+++ b/src/main/java/hamkke/board/domain/user/vo/Alias.java
@@ -33,4 +33,9 @@ public class Alias {
     public String getValue() {
         return value;
     }
+
+    public void changeValue(final String newAlias) {
+        validateByAliasPattern(newAlias);
+        this.value = newAlias;
+    }
 }

--- a/src/main/java/hamkke/board/service/UserService.java
+++ b/src/main/java/hamkke/board/service/UserService.java
@@ -3,7 +3,7 @@ package hamkke.board.service;
 import hamkke.board.domain.user.User;
 import hamkke.board.repository.UserRepository;
 import hamkke.board.service.dto.CreateUserRequest;
-import hamkke.board.service.dto.UserChangeAliasRequest;
+import hamkke.board.service.dto.UserAliasChangeRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -40,11 +40,11 @@ public class UserService {
     }
 
     @Transactional
-    public void changeAlias(final String loginId, final UserChangeAliasRequest userChangeAliasRequest) {
+    public void changeAlias(final String loginId, final UserAliasChangeRequest userAliasChangeRequest) {
         User user = findByLoginId(loginId);
 
         try {
-            user.changeAlias(userChangeAliasRequest.getNewAlias());
+            user.changeAlias(userAliasChangeRequest.getNewAlias());
         } catch (final DataIntegrityViolationException exception){
             UniqueConstraintCondition uniqueConstraintCondition = UniqueConstraintCondition.matchCondition(exception);
             throw uniqueConstraintCondition.generateException();

--- a/src/main/java/hamkke/board/service/UserService.java
+++ b/src/main/java/hamkke/board/service/UserService.java
@@ -3,6 +3,7 @@ package hamkke.board.service;
 import hamkke.board.domain.user.User;
 import hamkke.board.repository.UserRepository;
 import hamkke.board.service.dto.CreateUserRequest;
+import hamkke.board.service.dto.UserChangeAliasRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -36,5 +37,15 @@ public class UserService {
     public User findByLoginId(final String loginId) {
         return userRepository.findByLoginIdValue(loginId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 ID 입니다."));
+    }
+
+    @Transactional
+    public void changeAlias(final String loginId, final UserChangeAliasRequest userChangeAliasRequest) {
+        User user = userRepository.findByLoginIdValue(loginId)
+                .orElseThrow(() -> {
+                    log.info("존재하지 않는 loginId의 접근 : {}", loginId);
+                    throw new IllegalArgumentException("존재하지 않는 유저입니다.");
+                });
+        user.changeAlias(userChangeAliasRequest.getNewAlias());
     }
 }

--- a/src/main/java/hamkke/board/service/UserService.java
+++ b/src/main/java/hamkke/board/service/UserService.java
@@ -41,11 +41,13 @@ public class UserService {
 
     @Transactional
     public void changeAlias(final String loginId, final UserChangeAliasRequest userChangeAliasRequest) {
-        User user = userRepository.findByLoginIdValue(loginId)
-                .orElseThrow(() -> {
-                    log.info("존재하지 않는 loginId의 접근 : {}", loginId);
-                    throw new IllegalArgumentException("존재하지 않는 유저입니다.");
-                });
-        user.changeAlias(userChangeAliasRequest.getNewAlias());
+        User user = findByLoginId(loginId);
+
+        try {
+            user.changeAlias(userChangeAliasRequest.getNewAlias());
+        } catch (final DataIntegrityViolationException exception){
+            UniqueConstraintCondition uniqueConstraintCondition = UniqueConstraintCondition.matchCondition(exception);
+            throw uniqueConstraintCondition.generateException();
+        }
     }
 }

--- a/src/main/java/hamkke/board/service/dto/UserAliasChangeRequest.java
+++ b/src/main/java/hamkke/board/service/dto/UserAliasChangeRequest.java
@@ -9,13 +9,13 @@ import javax.validation.constraints.Pattern;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class UserChangeAliasRequest {
+public class UserAliasChangeRequest {
 
     @NotNull
     @Pattern(regexp = "^[a-z0-9가-힣]{2,8}$", message = "별칭은 특수문자와 영어(대문자)를 제외하여 1자 이상, 8자 이하여야 합니다.")
     private String newAlias;
 
-    public UserChangeAliasRequest(final String newAlias) {
+    public UserAliasChangeRequest(final String newAlias) {
         this.newAlias = newAlias;
     }
 }

--- a/src/main/java/hamkke/board/service/dto/UserChangeAliasRequest.java
+++ b/src/main/java/hamkke/board/service/dto/UserChangeAliasRequest.java
@@ -1,0 +1,21 @@
+package hamkke.board.service.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserChangeAliasRequest {
+
+    @NotNull
+    @Pattern(regexp = "^[a-z0-9가-힣]{2,8}$", message = "별칭은 특수문자와 영어(대문자)를 제외하여 1자 이상, 8자 이하여야 합니다.")
+    private String newAlias;
+
+    public UserChangeAliasRequest(final String newAlias) {
+        this.newAlias = newAlias;
+    }
+}

--- a/src/main/java/hamkke/board/web/argumentresolver/LoginUserArgumentResolver.java
+++ b/src/main/java/hamkke/board/web/argumentresolver/LoginUserArgumentResolver.java
@@ -17,15 +17,12 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
-        boolean hasLoginAnnotation = parameter.hasParameterAnnotation(Login.class);
-        boolean hasUserIdType = Long.class
-                .isAssignableFrom(parameter.getParameterType());
-        return hasLoginAnnotation && hasUserIdType;
+        return parameter.hasParameterAnnotation(Login.class);
     }
 
     @Override
     public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer, final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
         String authorizationHeader = webRequest.getHeader("Authorization");
-        return tokenResolver.getUserId(authorizationHeader);
+        return tokenResolver.getLoginId(authorizationHeader);
     }
 }

--- a/src/main/java/hamkke/board/web/jwt/TokenResolver.java
+++ b/src/main/java/hamkke/board/web/jwt/TokenResolver.java
@@ -36,7 +36,7 @@ public class TokenResolver {
                 .compact();
     }
 
-    public String getUserId(final String token) {
+    public String getLoginId(final String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(generateKey())
                 .build()

--- a/src/test/java/hamkke/board/controller/UserControllerTest.java
+++ b/src/test/java/hamkke/board/controller/UserControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -94,7 +95,7 @@ class UserControllerTest {
         UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("새로운별명");
 
         //when
-        ResultActions actual = mockMvc.perform(post("/api/user/change-alias").contentType(MediaType.APPLICATION_JSON)
+        ResultActions actual = mockMvc.perform(put("/api/user/change-alias").contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
 
         //then

--- a/src/test/java/hamkke/board/controller/UserControllerTest.java
+++ b/src/test/java/hamkke/board/controller/UserControllerTest.java
@@ -3,7 +3,7 @@ package hamkke.board.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hamkke.board.service.UserService;
 import hamkke.board.service.dto.CreateUserRequest;
-import hamkke.board.service.dto.UserChangeAliasRequest;
+import hamkke.board.service.dto.UserAliasChangeRequest;
 import hamkke.board.web.jwt.TokenResolver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -95,12 +95,13 @@ class UserControllerTest {
     void changeAlias() throws Exception {
         //given
         when(tokenResolver.getLoginId(anyString())).thenReturn("apple123");
-        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("새로운별명");
+        UserAliasChangeRequest userAliasChangeRequest = new UserAliasChangeRequest("새로운별명");
 
         //when
-        ResultActions actual = mockMvc.perform(put("/api/user/alias").contentType(MediaType.APPLICATION_JSON)
+        ResultActions actual = mockMvc.perform(put("/api/user/alias")
+                .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "accessToken")
-                .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
+                .content(objectMapper.writeValueAsString(userAliasChangeRequest)));
 
         //then
         actual.andExpect(status().isOk());
@@ -112,14 +113,15 @@ class UserControllerTest {
         //given
         when(tokenResolver.getLoginId(anyString())).thenReturn("apple123");
         doThrow(new IllegalArgumentException("별칭은 특수문자와 영어(대문자)를 제외하여 1자 이상, 8자 이하여야 합니다.")).when(userService)
-                .changeAlias(anyString(), any(UserChangeAliasRequest.class));
+                .changeAlias(anyString(), any(UserAliasChangeRequest.class));
 
-        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("사용못하는별명");
+        UserAliasChangeRequest userAliasChangeRequest = new UserAliasChangeRequest("사용못하는별명");
 
         //when
-        ResultActions actual = mockMvc.perform(put("/api/user/alias").contentType(MediaType.APPLICATION_JSON)
+        ResultActions actual = mockMvc.perform(put("/api/user/alias")
+                .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "accessToken")
-                .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
+                .content(objectMapper.writeValueAsString(userAliasChangeRequest)));
 
         //then
         actual.andExpect(status().isBadRequest())
@@ -132,14 +134,15 @@ class UserControllerTest {
         //given
         when(tokenResolver.getLoginId(anyString())).thenReturn("apple123");
         doThrow(new IllegalArgumentException("이미 존재하는 별명입니다.")).when(userService)
-                .changeAlias(anyString(), any(UserChangeAliasRequest.class));
+                .changeAlias(anyString(), any(UserAliasChangeRequest.class));
 
-        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("이미존재하는별명");
+        UserAliasChangeRequest userAliasChangeRequest = new UserAliasChangeRequest("이미존재하는별명");
 
         //when
-        ResultActions actual = mockMvc.perform(put("/api/user/alias").contentType(MediaType.APPLICATION_JSON)
+        ResultActions actual = mockMvc.perform(put("/api/user/alias")
+                .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "accessToken")
-                .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
+                .content(objectMapper.writeValueAsString(userAliasChangeRequest)));
 
         //then
         actual.andExpect(status().isBadRequest())
@@ -152,14 +155,15 @@ class UserControllerTest {
         //given
         when(tokenResolver.getLoginId(anyString())).thenReturn("apple123");
         doThrow(new IllegalArgumentException("존재하지 않는 ID 입니다.")).when(userService)
-                .changeAlias(anyString(), any(UserChangeAliasRequest.class));
+                .changeAlias(anyString(), any(UserAliasChangeRequest.class));
 
-        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("새로운별명");
+        UserAliasChangeRequest userAliasChangeRequest = new UserAliasChangeRequest("새로운별명");
 
         //when
-        ResultActions actual = mockMvc.perform(put("/api/user/alias").contentType(MediaType.APPLICATION_JSON)
+        ResultActions actual = mockMvc.perform(put("/api/user/alias")
+                .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "accessToken")
-                .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
+                .content(objectMapper.writeValueAsString(userAliasChangeRequest)));
 
         //then
         actual.andExpect(status().isBadRequest())

--- a/src/test/java/hamkke/board/controller/UserControllerTest.java
+++ b/src/test/java/hamkke/board/controller/UserControllerTest.java
@@ -94,10 +94,12 @@ class UserControllerTest {
     @DisplayName("별명 변경 시, 새로운 별명을 입력받고 변경 후, HTTP 200 상태코드를 반환한다.")
     void changeAlias() throws Exception {
         //given
+        when(tokenResolver.getLoginId(anyString())).thenReturn("apple123");
         UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("새로운별명");
 
         //when
         ResultActions actual = mockMvc.perform(put("/api/user/alias").contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "accessToken")
                 .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
 
         //then
@@ -112,12 +114,11 @@ class UserControllerTest {
         doThrow(new IllegalArgumentException("별칭은 특수문자와 영어(대문자)를 제외하여 1자 이상, 8자 이하여야 합니다.")).when(userService)
                 .changeAlias(anyString(), any(UserChangeAliasRequest.class));
 
-        String inputLoginId = "apple123";
         UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("사용못하는별명");
 
         //when
         ResultActions actual = mockMvc.perform(put("/api/user/alias").contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", inputLoginId)
+                .header("Authorization", "accessToken")
                 .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
 
         //then
@@ -133,12 +134,11 @@ class UserControllerTest {
         doThrow(new IllegalArgumentException("이미 존재하는 별명입니다.")).when(userService)
                 .changeAlias(anyString(), any(UserChangeAliasRequest.class));
 
-        String inputLoginId = "apple123";
         UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("이미존재하는별명");
 
         //when
         ResultActions actual = mockMvc.perform(put("/api/user/alias").contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", inputLoginId)
+                .header("Authorization", "accessToken")
                 .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
 
         //then
@@ -154,12 +154,11 @@ class UserControllerTest {
         doThrow(new IllegalArgumentException("존재하지 않는 ID 입니다.")).when(userService)
                 .changeAlias(anyString(), any(UserChangeAliasRequest.class));
 
-        String inputLoginId = "apple123";
         UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("새로운별명");
 
         //when
         ResultActions actual = mockMvc.perform(put("/api/user/alias").contentType(MediaType.APPLICATION_JSON)
-                .header("Authorization", inputLoginId)
+                .header("Authorization", "accessToken")
                 .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
 
         //then

--- a/src/test/java/hamkke/board/controller/UserControllerTest.java
+++ b/src/test/java/hamkke/board/controller/UserControllerTest.java
@@ -97,7 +97,7 @@ class UserControllerTest {
         UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("새로운별명");
 
         //when
-        ResultActions actual = mockMvc.perform(put("/api/user/change-alias").contentType(MediaType.APPLICATION_JSON)
+        ResultActions actual = mockMvc.perform(put("/api/user/alias").contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
 
         //then

--- a/src/test/java/hamkke/board/controller/UserControllerTest.java
+++ b/src/test/java/hamkke/board/controller/UserControllerTest.java
@@ -126,11 +126,32 @@ class UserControllerTest {
     }
 
     @Test
+    @DisplayName("별명 변경 시, 새로운 별명이 이미 존재한다면, HTTP 400 상태코드를 반환한다.")
+    void changeAliasFailedByDuplicationAlias() throws Exception {
+        //given
+        when(tokenResolver.getLoginId(anyString())).thenReturn("apple123");
+        doThrow(new IllegalArgumentException("이미 존재하는 별명입니다.")).when(userService)
+                .changeAlias(anyString(), any(UserChangeAliasRequest.class));
+
+        String inputLoginId = "apple123";
+        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("이미존재하는별명");
+
+        //when
+        ResultActions actual = mockMvc.perform(put("/api/user/alias").contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", inputLoginId)
+                .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
+
+        //then
+        actual.andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("이미 존재하는 별명입니다."));
+    }
+
+    @Test
     @DisplayName("별명 변경 시, 새로운 별명을 입력받고 변경 중 로그인 아이디가 존재하지 않는다면, HTTP 400 상태코드를 반환한다.")
     void changeAliasFailedByIncorrectLoginId() throws Exception {
         //given
         when(tokenResolver.getLoginId(anyString())).thenReturn("apple123");
-        doThrow(new IllegalArgumentException("존재하지 않는 유저입니다.")).when(userService)
+        doThrow(new IllegalArgumentException("존재하지 않는 ID 입니다.")).when(userService)
                 .changeAlias(anyString(), any(UserChangeAliasRequest.class));
 
         String inputLoginId = "apple123";
@@ -143,6 +164,6 @@ class UserControllerTest {
 
         //then
         actual.andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error").value("존재하지 않는 유저입니다."));
+                .andExpect(jsonPath("$.error").value("존재하지 않는 ID 입니다."));
     }
 }

--- a/src/test/java/hamkke/board/controller/UserControllerTest.java
+++ b/src/test/java/hamkke/board/controller/UserControllerTest.java
@@ -155,7 +155,7 @@ class UserControllerTest {
                 .changeAlias(anyString(), any(UserChangeAliasRequest.class));
 
         String inputLoginId = "apple123";
-        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("사용못하는별명");
+        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("새로운별명");
 
         //when
         ResultActions actual = mockMvc.perform(put("/api/user/alias").contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/hamkke/board/controller/UserControllerTest.java
+++ b/src/test/java/hamkke/board/controller/UserControllerTest.java
@@ -115,13 +115,13 @@ class UserControllerTest {
         doThrow(new IllegalArgumentException("별칭은 특수문자와 영어(대문자)를 제외하여 1자 이상, 8자 이하여야 합니다.")).when(userService)
                 .changeAlias(anyString(), any(UserAliasChangeRequest.class));
 
-        UserAliasChangeRequest userAliasChangeRequest = new UserAliasChangeRequest("사용못하는별명");
+        UserAliasChangeRequest incorrectAliasChangeRequest = new UserAliasChangeRequest("사용못하는별명");
 
         //when
         ResultActions actual = mockMvc.perform(put("/api/user/alias")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "accessToken")
-                .content(objectMapper.writeValueAsString(userAliasChangeRequest)));
+                .content(objectMapper.writeValueAsString(incorrectAliasChangeRequest)));
 
         //then
         actual.andExpect(status().isBadRequest())
@@ -136,13 +136,13 @@ class UserControllerTest {
         doThrow(new IllegalArgumentException("이미 존재하는 별명입니다.")).when(userService)
                 .changeAlias(anyString(), any(UserAliasChangeRequest.class));
 
-        UserAliasChangeRequest userAliasChangeRequest = new UserAliasChangeRequest("이미존재하는별명");
+        UserAliasChangeRequest existingAliasChangeRequest = new UserAliasChangeRequest("이미존재하는별명");
 
         //when
         ResultActions actual = mockMvc.perform(put("/api/user/alias")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header("Authorization", "accessToken")
-                .content(objectMapper.writeValueAsString(userAliasChangeRequest)));
+                .content(objectMapper.writeValueAsString(existingAliasChangeRequest)));
 
         //then
         actual.andExpect(status().isBadRequest())

--- a/src/test/java/hamkke/board/controller/UserControllerTest.java
+++ b/src/test/java/hamkke/board/controller/UserControllerTest.java
@@ -3,6 +3,7 @@ package hamkke.board.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import hamkke.board.service.UserService;
 import hamkke.board.service.dto.CreateUserRequest;
+import hamkke.board.service.dto.UserChangeAliasRequest;
 import hamkke.board.web.jwt.TokenResolver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -84,5 +85,35 @@ class UserControllerTest {
         //then
         actual.andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.error").value("이미 존재하는 별명 입니다."));
+    }
+
+    @Test
+    @DisplayName("별명 변경 시, 새로운 별명을 입력받으면 HTTP 200 상태코드를 반환한다.")
+    void changeAlias() throws Exception {
+        //given
+        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("새로운별명");
+
+        //when
+        ResultActions actual = mockMvc.perform(post("/api/user/change-alias").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
+
+        //then
+        actual.andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("별명 변경 시, 이미 사용중인 별명이라면 HTTP 400 상태코드를 반환한다.")
+    void changeAliasFailedByDuplication() throws Exception {
+        //given
+        when(userService.changeAlias(any(UserChangeAliasRequest.class))).thenThrow(new IllegalArgumentException("이미 사용중인 별명입니다."));
+
+        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("존재하는별명");
+
+        //when
+        ResultActions actual = mockMvc.perform(post("/api/user/change-alias").contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userChangeAliasRequest)));
+
+        //then
+        actual.andExpect(status().isOk());
     }
 }

--- a/src/test/java/hamkke/board/controller/UserControllerTest.java
+++ b/src/test/java/hamkke/board/controller/UserControllerTest.java
@@ -105,7 +105,7 @@ class UserControllerTest {
     @DisplayName("별명 변경 시, 이미 사용중인 별명이라면 HTTP 400 상태코드를 반환한다.")
     void changeAliasFailedByDuplication() throws Exception {
         //given
-        when(userService.changeAlias(any(UserChangeAliasRequest.class))).thenThrow(new IllegalArgumentException("이미 사용중인 별명입니다."));
+        when(userService.changeAlias(any(UserChangeAliasRequest.class))).thenThrow(new IllegalArgumentException("이미 존재하는 별명입니다."));
 
         UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("존재하는별명");
 

--- a/src/test/java/hamkke/board/domain/user/UserTest.java
+++ b/src/test/java/hamkke/board/domain/user/UserTest.java
@@ -1,0 +1,70 @@
+package hamkke.board.domain.user;
+
+import hamkke.board.domain.bulletin.Bulletin;
+import hamkke.board.domain.user.vo.Alias;
+import hamkke.board.domain.user.vo.LoginId;
+import hamkke.board.domain.user.vo.Password;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    private User createUser() {
+        final String loginId = "apple123";
+        final String password = "apple123!!";
+        final String alias = "삼다수";
+        return new User(loginId, password, alias);
+    }
+
+    private Bulletin createBulletin(final User author) {
+        final String title = "sample title";
+        final String content = "sample content";
+        return new Bulletin(title, content, author);
+    }
+
+    @Test
+    @DisplayName("유저 아이디, 비밀번호, 별칭, 생성 일자를 반환한다.")
+    void getValues() {
+        //given
+        SoftAssertions softly = new SoftAssertions();
+        User user = createUser();
+
+        //when, then
+        softly.assertThat(user.getLoginId()).isEqualTo(new LoginId("apple123"));
+        softly.assertThat(user.getPassword()).isEqualTo(new Password("apple123!!"));
+        softly.assertThat(user.getAlias()).isEqualTo(new Alias("삼다수"));
+        softly.assertAll();
+    }
+
+    @Test
+    @DisplayName("연관 관계 편의 메서드")
+    void addBulletin() {
+        //given
+        User user = createUser();
+        Bulletin bulletin = createBulletin(user);
+
+        //when
+        user.addBulletin(bulletin);
+
+        //then
+        assertThat(user.getBulletins()).contains(bulletin);
+    }
+
+
+    @Test
+    @DisplayName("Alias 를 변경한다.")
+    void changeAlias() {
+        //given
+        User user = createUser();
+        String newAlias = "백산수";
+
+        //when
+        user.changeAlias(newAlias);
+
+        //then
+        assertThat(user.getAlias().getValue()).isEqualTo("백산수");
+    }
+}

--- a/src/test/java/hamkke/board/domain/user/UserTest.java
+++ b/src/test/java/hamkke/board/domain/user/UserTest.java
@@ -59,11 +59,12 @@ class UserTest {
         //given
         User user = createUser();
         String newAlias = "백산수";
+        Alias expect = new Alias(newAlias);
 
         //when
         user.changeAlias(newAlias);
 
         //then
-        assertThat(user.getAlias().getValue()).isEqualTo("백산수");
+        assertThat(user.getAlias()).isEqualTo(expect);
     }
 }

--- a/src/test/java/hamkke/board/domain/user/UserTest.java
+++ b/src/test/java/hamkke/board/domain/user/UserTest.java
@@ -5,6 +5,7 @@ import hamkke.board.domain.user.vo.Alias;
 import hamkke.board.domain.user.vo.LoginId;
 import hamkke.board.domain.user.vo.Password;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -12,17 +13,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class UserTest {
 
-    private User createUser() {
-        final String loginId = "apple123";
-        final String password = "apple123!!";
-        final String alias = "삼다수";
-        return new User(loginId, password, alias);
-    }
+    private User user;
 
-    private Bulletin createBulletin(final User author) {
-        final String title = "sample title";
-        final String content = "sample content";
-        return new Bulletin(title, content, author);
+    @BeforeEach
+    void setUp() {
+        user = new User("apple123", "apple123!!", "삼다수");
     }
 
     @Test
@@ -30,7 +25,6 @@ class UserTest {
     void getValues() {
         //given
         SoftAssertions softly = new SoftAssertions();
-        User user = createUser();
 
         //when, then
         softly.assertThat(user.getLoginId()).isEqualTo(new LoginId("apple123"));
@@ -43,7 +37,6 @@ class UserTest {
     @DisplayName("연관 관계 편의 메서드")
     void addBulletin() {
         //given
-        User user = createUser();
         Bulletin bulletin = createBulletin(user);
 
         //when
@@ -53,11 +46,16 @@ class UserTest {
         assertThat(user.getBulletins()).contains(bulletin);
     }
 
+    private Bulletin createBulletin(final User author) {
+        final String title = "sample title";
+        final String content = "sample content";
+        return new Bulletin(title, content, author);
+    }
+
     @Test
     @DisplayName("Alias 를 변경한다.")
     void changeAlias() {
         //given
-        User user = createUser();
         String newAlias = "백산수";
         Alias expect = new Alias(newAlias);
 

--- a/src/test/java/hamkke/board/domain/user/UserTest.java
+++ b/src/test/java/hamkke/board/domain/user/UserTest.java
@@ -53,7 +53,6 @@ class UserTest {
         assertThat(user.getBulletins()).contains(bulletin);
     }
 
-
     @Test
     @DisplayName("Alias 를 변경한다.")
     void changeAlias() {

--- a/src/test/java/hamkke/board/domain/user/vo/AliasTest.java
+++ b/src/test/java/hamkke/board/domain/user/vo/AliasTest.java
@@ -39,4 +39,18 @@ class AliasTest {
         //then
         assertThat(actual).isEqualTo("사과왕77");
     }
+
+    @Test
+    @DisplayName("별칭을 변경한다.")
+    void changeValue() {
+        //given
+        Alias alias = new Alias("삼다수");
+        String input = "백산수";
+
+        //when
+        alias.changeValue(input);
+
+        //then
+        assertThat(alias.getValue()).isEqualTo("백산수");
+    }
 }

--- a/src/test/java/hamkke/board/domain/user/vo/AliasTest.java
+++ b/src/test/java/hamkke/board/domain/user/vo/AliasTest.java
@@ -19,7 +19,7 @@ class AliasTest {
 
     @ParameterizedTest
     @DisplayName("별칭은 특수문자와 영어(대문자)를 제외하여 8자 이하여야 합니다. 그렇지 않은 경우 예외를 발생한다.")
-    @ValueSource(strings = {"!apple", "APPLE", "가나다라마바사아자","a", " ", ""})
+    @ValueSource(strings = {"!apple", "APPLE", "가나다라마바사아자", "a", " ", ""})
     void validateAlias(final String inputAlias) {
         //when, then
         assertThatThrownBy(() -> new Alias(inputAlias)).isInstanceOf(IllegalArgumentException.class)
@@ -52,5 +52,17 @@ class AliasTest {
 
         //then
         assertThat(alias.getValue()).isEqualTo("백산수");
+    }
+
+    @ParameterizedTest
+    @DisplayName("별칭 변경 시, 지정된 제약조건(별칭은 특수문자와 영어(대문자)를 제외하여 8자 이하여야 한다.)에 위배되면 예외를 발생한다.")
+    @ValueSource(strings = {"!apple", "APPLE", "가나다라마바사아자", "a", " ", ""})
+    void validateWhenChangeAlias(final String newAlias) {
+        //given
+        Alias alias = new Alias("삼다수");
+
+        //when, then
+        assertThatThrownBy(() -> alias.changeValue(newAlias))
+                .hasMessage("별칭은 특수문자와 영어(대문자)를 제외하여 1자 이상, 8자 이하여야 합니다.");
     }
 }

--- a/src/test/java/hamkke/board/service/UserServiceTest.java
+++ b/src/test/java/hamkke/board/service/UserServiceTest.java
@@ -4,7 +4,7 @@ import hamkke.board.domain.user.User;
 import hamkke.board.domain.user.vo.LoginId;
 import hamkke.board.repository.UserRepository;
 import hamkke.board.service.dto.CreateUserRequest;
-import hamkke.board.service.dto.UserChangeAliasRequest;
+import hamkke.board.service.dto.UserAliasChangeRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -91,10 +91,10 @@ class UserServiceTest {
         //given
         when(userRepository.findByLoginIdValue(anyString())).thenReturn(Optional.of(user));
         String loginId = "apple123";
-        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("백산수");
+        UserAliasChangeRequest userAliasChangeRequest = new UserAliasChangeRequest("백산수");
 
         //when
-        userService.changeAlias(loginId, userChangeAliasRequest);
+        userService.changeAlias(loginId, userAliasChangeRequest);
 
         //then
         verify(userRepository, times(1)).findByLoginIdValue(anyString());
@@ -108,10 +108,10 @@ class UserServiceTest {
         when(userRepository.findByLoginIdValue(anyString())).thenReturn(Optional.empty());
 
         String loginId = "apple123";
-        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("새로운별명");
+        UserAliasChangeRequest userAliasChangeRequest = new UserAliasChangeRequest("새로운별명");
 
         //when, then
-        assertThatThrownBy(() -> userService.changeAlias(loginId, userChangeAliasRequest)).isInstanceOf(IllegalArgumentException.class)
+        assertThatThrownBy(() -> userService.changeAlias(loginId, userAliasChangeRequest)).isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("존재하지 않는 ID 입니다.");
     }
 
@@ -124,10 +124,10 @@ class UserServiceTest {
                 .changeAlias(anyString());
 
         String loginId = "apple123";
-        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("백산수");
+        UserAliasChangeRequest alreadyExistedAlias = new UserAliasChangeRequest("백산수");
 
         //when, then
-        assertThatThrownBy(() -> userService.changeAlias(loginId, userChangeAliasRequest)).isInstanceOf(IllegalStateException.class)
+        assertThatThrownBy(() -> userService.changeAlias(loginId, alreadyExistedAlias)).isInstanceOf(IllegalStateException.class)
                 .hasMessage("이미 존재하는 별명 입니다.");
     }
 }

--- a/src/test/java/hamkke/board/service/UserServiceTest.java
+++ b/src/test/java/hamkke/board/service/UserServiceTest.java
@@ -124,10 +124,10 @@ class UserServiceTest {
                 .changeAlias(anyString());
 
         String loginId = "apple123";
-        UserAliasChangeRequest alreadyExistedAlias = new UserAliasChangeRequest("백산수");
+        UserAliasChangeRequest existingAliasRequest = new UserAliasChangeRequest("백산수");
 
         //when, then
-        assertThatThrownBy(() -> userService.changeAlias(loginId, alreadyExistedAlias)).isInstanceOf(IllegalStateException.class)
+        assertThatThrownBy(() -> userService.changeAlias(loginId, existingAliasRequest)).isInstanceOf(IllegalStateException.class)
                 .hasMessage("이미 존재하는 별명 입니다.");
     }
 }

--- a/src/test/java/hamkke/board/service/UserServiceTest.java
+++ b/src/test/java/hamkke/board/service/UserServiceTest.java
@@ -4,12 +4,15 @@ import hamkke.board.domain.user.User;
 import hamkke.board.domain.user.vo.LoginId;
 import hamkke.board.repository.UserRepository;
 import hamkke.board.service.dto.CreateUserRequest;
+import hamkke.board.service.dto.UserChangeAliasRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -79,5 +82,21 @@ class UserServiceTest {
         //when, then
         assertThatThrownBy(() -> userService.join(duplicated)).isInstanceOf(IllegalStateException.class)
                 .hasMessage("이미 존재하는 별명 입니다.");
+    }
+
+    @Test
+    @DisplayName("User 의 Alias 를 변경한다.")
+    void changeAlias() {
+        //given
+        when(userRepository.findByLoginIdValue(anyString())).thenReturn(Optional.of(user));
+        String loginId = "apple123";
+        UserChangeAliasRequest userChangeAliasRequest = new UserChangeAliasRequest("백산수");
+
+        //when
+        userService.changeAlias(loginId, userChangeAliasRequest);
+
+        //then
+        verify(userRepository, times(1)).findByLoginIdValue(anyString());
+        verify(user,times(1)).changeAlias(anyString());
     }
 }

--- a/src/test/java/hamkke/board/web/jwt/TokenResolverTest.java
+++ b/src/test/java/hamkke/board/web/jwt/TokenResolverTest.java
@@ -41,7 +41,7 @@ class TokenResolverTest {
         String expectLoginId = "apple123";
 
         //when
-        String actual = tokenResolver.getUserId(token);
+        String actual = tokenResolver.getLoginId(token);
 
         //then
         assertThat(actual).isEqualTo(expectLoginId);


### PR DESCRIPTION
## 개요

- 이슈번호 #52 
- 이슈번호 #63 


## 작업사항

- 회원 별명 변경 기능 구현
- 기존 작업 중 누락된 UserTest 코드 재작성
- 작업 중 LoginUserArgumentResolver 에 대한 문제가 발생해 바로 수정하였습니다.

## 그 외 참고 사항

- 기존에 있던 세개의 브랜치를 병합해서 작업을 하기 때문에 이전에 사용했던 이슈 번호 및 브랜치들을 삭제했기 때문에 병합 후 , 이후 작업은 이슈번호 #52 로 커밋을 남겨두었습니다.

