### PR TITLE
Feature/#64/전박적인 코드 리팩토링

### DIFF
--- a/src/main/java/hamkke/board/domain/user/vo/Alias.java
+++ b/src/main/java/hamkke/board/domain/user/vo/Alias.java
@@ -26,7 +26,7 @@ public class Alias {
 
     private void validateByAliasPattern(final String alias) {
         if (!ALIAS_PATTERN.matcher(alias).matches()) {
-            throw new IllegalArgumentException("별칭은 특수문자와 영어(대문자)를 제외하여 1자 이상, 8자 이하여야 합니다.");
+            throw new IllegalArgumentException("별칭은 특수문자와 영어(대문자)를 제외하여 2자 이상, 8자 이하여야 합니다.");
         }
     }
 

--- a/src/test/java/hamkke/board/controller/AuthenticationControllerTest.java
+++ b/src/test/java/hamkke/board/controller/AuthenticationControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -30,9 +31,6 @@ class AuthenticationControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @MockBean
-    private JwtTokenResponse jwtTokenResponse;
 
     @MockBean
     private TokenResolver tokenResolver;
@@ -80,9 +78,10 @@ class AuthenticationControllerTest {
             "HTTP 200 상태코드를 반환한다.")
     void reissueToken() throws Exception {
         //given
-        when(authenticationService.reissue(any(RefreshTokenRequest.class))).thenReturn(jwtTokenResponse);
+        JwtTokenResponse jwtTokenResponse = mock(JwtTokenResponse.class);
         when(jwtTokenResponse.getAccessToken()).thenReturn("new Access Token");
         when(jwtTokenResponse.getRefreshToken()).thenReturn("new Refresh Token");
+        when(authenticationService.reissue(any(RefreshTokenRequest.class))).thenReturn(jwtTokenResponse);
 
         RefreshTokenRequest refreshTokenRequest = new RefreshTokenRequest("Refresh Token");
 

--- a/src/test/java/hamkke/board/controller/AuthenticationControllerTest.java
+++ b/src/test/java/hamkke/board/controller/AuthenticationControllerTest.java
@@ -48,7 +48,8 @@ class AuthenticationControllerTest {
         when(authenticationService.login(any(LoginRequest.class))).thenReturn(loginResponse);
 
         //when
-        ResultActions actual = mockMvc.perform(post("/api/authentication/login").contentType(MediaType.APPLICATION_JSON)
+        ResultActions actual = mockMvc.perform(post("/api/authentication/login")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(loginRequest)));
 
         //then
@@ -65,7 +66,8 @@ class AuthenticationControllerTest {
         when(authenticationService.login(any(LoginRequest.class))).thenThrow(new IllegalArgumentException("비밀번호가 일치하지 않습니다."));
 
         //when
-        ResultActions actual = mockMvc.perform(post("/api/authentication/login").contentType(MediaType.APPLICATION_JSON)
+        ResultActions actual = mockMvc.perform(post("/api/authentication/login")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(loginRequest)));
 
         //then
@@ -86,7 +88,8 @@ class AuthenticationControllerTest {
         RefreshTokenRequest refreshTokenRequest = new RefreshTokenRequest("Refresh Token");
 
         //when
-        ResultActions actual = mockMvc.perform(post("/api/authentication/reissueToken").contentType(MediaType.APPLICATION_JSON)
+        ResultActions actual = mockMvc.perform(post("/api/authentication/reissueToken")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(refreshTokenRequest)));
 
         //then
@@ -103,7 +106,8 @@ class AuthenticationControllerTest {
         RefreshTokenRequest refreshTokenRequest = new RefreshTokenRequest("Refresh Token");
 
         //when
-        ResultActions actual = mockMvc.perform(post("/api/authentication/reissueToken").contentType(MediaType.APPLICATION_JSON)
+        ResultActions actual = mockMvc.perform(post("/api/authentication/reissueToken")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(refreshTokenRequest)));
 
         //then

--- a/src/test/java/hamkke/board/controller/UserControllerTest.java
+++ b/src/test/java/hamkke/board/controller/UserControllerTest.java
@@ -43,9 +43,9 @@ class UserControllerTest {
         CreateUserRequest createUserRequest = new CreateUserRequest("apple123", "apple123!!", "아이폰");
 
         //when
-        ResultActions actual = mockMvc.perform(
-                post("/api/user/join").contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(createUserRequest)));
+        ResultActions actual = mockMvc.perform(post("/api/user/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createUserRequest)));
 
         //then
         actual.andExpect(status().isCreated())
@@ -61,7 +61,8 @@ class UserControllerTest {
         CreateUserRequest duplicated = new CreateUserRequest("apple123", "apple123!!", "아이시스");
 
         //when
-        ResultActions actual = mockMvc.perform(post("/api/user/join").contentType(MediaType.APPLICATION_JSON)
+        ResultActions actual = mockMvc.perform(post("/api/user/join")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(duplicated)));
 
         //then
@@ -78,7 +79,8 @@ class UserControllerTest {
         CreateUserRequest duplicated = new CreateUserRequest("banana123", "apple123!!", "아이시스");
 
         //when
-        ResultActions actual = mockMvc.perform(post("/api/user/join").contentType(MediaType.APPLICATION_JSON)
+        ResultActions actual = mockMvc.perform(post("/api/user/join")
+                .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(duplicated)));
 
         //then

--- a/src/test/java/hamkke/board/domain/user/vo/AliasTest.java
+++ b/src/test/java/hamkke/board/domain/user/vo/AliasTest.java
@@ -23,7 +23,7 @@ class AliasTest {
     void validateAlias(final String inputAlias) {
         //when, then
         assertThatThrownBy(() -> new Alias(inputAlias)).isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("별칭은 특수문자와 영어(대문자)를 제외하여 1자 이상, 8자 이하여야 합니다.");
+                .hasMessage("별칭은 특수문자와 영어(대문자)를 제외하여 2자 이상, 8자 이하여야 합니다.");
     }
 
     @Test

--- a/src/test/java/hamkke/board/service/AuthenticationServiceTest.java
+++ b/src/test/java/hamkke/board/service/AuthenticationServiceTest.java
@@ -1,6 +1,7 @@
 package hamkke.board.service;
 
 import hamkke.board.domain.user.User;
+import hamkke.board.domain.user.vo.Alias;
 import hamkke.board.domain.user.vo.LoginId;
 import hamkke.board.repository.RefreshTokenRepository;
 import hamkke.board.service.dto.JwtTokenResponse;
@@ -37,11 +38,6 @@ class AuthenticationServiceTest {
     @Mock
     private TokenResolver tokenResolver;
 
-    @Mock
-    private User user;
-
-    @Mock
-    private RefreshToken refreshToken;
 
     @InjectMocks
     private AuthenticationService authenticationService;
@@ -52,7 +48,9 @@ class AuthenticationServiceTest {
     @DisplayName("회원의 LoginId, 비밀번호를 입력받고 refresh 토큰이 없다면, Refresh 토큰을 생성한 후, 로그인 정보를 DTO 에 담아 반환한다.")
     void login() {
         //given
-        user = new User("apple123", "apple123!!", "삼다수");
+        User user = mock(User.class);
+        when(user.getLoginId()).thenReturn(new LoginId("apple123"));
+        when(user.getAlias()).thenReturn(new Alias("삼다수"));
         when(userService.findByLoginId(anyString())).thenReturn(user);
         when(tokenResolver.createToken(any())).thenReturn("test Access Token");
 
@@ -73,9 +71,12 @@ class AuthenticationServiceTest {
     @DisplayName("회원의 LoginId, 비밀번호를 입력받고 refresh 토큰이 있다면, Refresh 재생성하여 교체한 후, 로그인 정보를 DTO 에 담아 반환한다.")
     void loginWhenExistingRefreshToken() {
         //given
-        user = new User("apple123", "apple123!!", "삼다수");
+        User user = mock(User.class);
+        when(user.getLoginId()).thenReturn(new LoginId("apple123"));
+        when(user.getAlias()).thenReturn(new Alias("삼다수"));
         when(userService.findByLoginId(anyString())).thenReturn(user);
         when(tokenResolver.createToken(any())).thenReturn("test Access Token");
+        RefreshToken refreshToken = mock(RefreshToken.class);
         when(refreshTokenRepository.findByLoginIdValue(anyString())).thenReturn(Optional.of(refreshToken));
 
         LoginRequest loginRequest = new LoginRequest("apple123", "apple123!!");
@@ -108,6 +109,7 @@ class AuthenticationServiceTest {
     @DisplayName("로그인 요청 시, 입력받은 loginId 와 password 가 일치하지 않은 경우 예외를 반환한다.")
     void loginFailedByNotMatchingPassword() {
         //given
+        User user = mock(User.class);
         doThrow(new IllegalArgumentException("비밀번호가 일치하지 않습니다.")).when(user)
                 .checkPassword(anyString());
         when(userService.findByLoginId(anyString())).thenReturn(user);
@@ -123,10 +125,10 @@ class AuthenticationServiceTest {
     @DisplayName("RefreshToken 을 입력 받아 유효한지 확인 하고, 유효한 경우 AccessToken 과 RefreshToken 을 재발급 하여 DTO 에 담아 반환한다.")
     void reissueAccessTokenAndRefreshToken() {
         //given
+        RefreshToken refreshToken = mock(RefreshToken.class);
         when(refreshTokenRepository.findByToken(anyString())).thenReturn(Optional.of(refreshToken));
         when(refreshToken.getLoginId()).thenReturn(new LoginId("apple123"));
-        user = new User("apple123", "apple123!!", "삼다수");
-        when(userService.findByLoginId(anyString())).thenReturn(user);
+        when(userService.findByLoginId(anyString())).thenReturn(new User("apple123","apple123!!","삼다수"));
         when(tokenResolver.createToken(anyString())).thenReturn("test access Token");
 
         RefreshTokenRequest refreshTokenRequest = new RefreshTokenRequest("refresh Token");


### PR DESCRIPTION
## 개요

- 이슈번호 #64 
- 작업 내용 
   코드 리팩 토링

## 작업사항

-  테스트 코드 내 전역적으로 생성한 mock 객체를 사용하는 곳에서만 활용하도록 변경
- alias 제약 조건 위반 시 예외 메세지 변경

## 그 외 참고 사항

- AuthenticationServiceTest 코드를 변경해보았습니다. 전역적으로 사용하지 않는 Mock 객체들은 각 테스트 코드에서 모킹을 하도록 변경해보았습니다.  그런데 각테스트에서 모킹을 하는 코드가 더 늘어나는? 상황이 되어버렸습니다.
- 이런 방식으로 모킹을 해도 괜찮은지 여쭤봅니다.
